### PR TITLE
Reordered the instruction to avoid ignored files

### DIFF
--- a/_docs/getting-started/recipes.md
+++ b/_docs/getting-started/recipes.md
@@ -75,7 +75,7 @@ git commit -a -m "Adding Singularity file."
 git push origin master  
 ```
 
-Since I am in Automated Build mode(by default), the push will triger builds in Singularity Hub. 
+Since I am in Automated Build mode (the default), the push alone will trigger a build for my collection in Singularity Hub. 
 
 Please note that in the Automated Build mode, Singularity Hub will only consider file changes from the push after the connection being established. That is, if one Singularity file is created before the connection, it would not be considered by Singularity Hub, unless you modified it in the following push.
 

--- a/_docs/getting-started/recipes.md
+++ b/_docs/getting-started/recipes.md
@@ -65,7 +65,7 @@ Then two images will be built, `shub://vsoch/hello-world:latest` and `shub://vso
 
 # Building your Container
 
-To begin with, I would log in to Singularity Hub with my Github account and [add the repository](https://singularity-hub.org/collections/new), the repository in which I will put my files and data. A collection of builds, a Container Collection, is associated with a single repository. 
+After logging in to Singularity Hub with your GitHub account, you can [create a new collection](https://singularity-hub.org/collections/new), which means making a connection to some GitHub repository where you've put your files and data. This collection of builds, a Container Collection, is associated with a single repository. 
 
 Let's say that I create then a recipe in this repository. I would add the file, and push to Github.
 

--- a/_docs/getting-started/recipes.md
+++ b/_docs/getting-started/recipes.md
@@ -77,6 +77,6 @@ git push origin master
 
 Since I am in Automated Build mode (the default), the push alone will trigger a build for my collection in Singularity Hub. 
 
-Please note that in the Automated Build mode, Singularity Hub will only consider file changes from the push after the connection being established. That is, if one Singularity file is created before the connection, it would not be considered by Singularity Hub, unless you modified it in the following push.
+Please note that in the Automated Build mode, Singularity Hub will only consider file changes from the push after the connection has been established. That is, if one Singularity file is created before the connection, it would not be seen by Singularity Hub unless you modified it in the following push. Also note that recipes are discovered by way of the Singularity.* prefix, so make sure that you name your files accordingly. The suffix (after `Singularity.`) is used for the container tag.
 
 Next, you might want to explore your [options for building](../builds) or read about [build limits](../regulatory/limits)

--- a/_docs/getting-started/recipes.md
+++ b/_docs/getting-started/recipes.md
@@ -67,7 +67,7 @@ Then two images will be built, `shub://vsoch/hello-world:latest` and `shub://vso
 
 After logging in to Singularity Hub with your GitHub account, you can [create a new collection](https://singularity-hub.org/collections/new), which means making a connection to some GitHub repository where you've put your files and data. This collection of builds, a Container Collection, is associated with a single repository. 
 
-Let's say that I create then a recipe in this repository. I would add the file, and push to Github.
+Let's say that I create a recipe in this repository. I would add the file, and push to GitHub.
 
 ```bash
 git add Singularity  

--- a/_docs/getting-started/recipes.md
+++ b/_docs/getting-started/recipes.md
@@ -65,7 +65,9 @@ Then two images will be built, `shub://vsoch/hello-world:latest` and `shub://vso
 
 # Building your Container
 
-Let's say that we created a recipe. I would add this file to one of my Github repositories, and push to Github.
+To begin with, I would log in to Singularity Hub with my Github account and [add the repository](https://singularity-hub.org/collections/new), the repository in which I will put my files and data. A collection of builds, a Container Collection, is associated with a single repository. 
+
+Let's say that I create then a recipe in this repository. I would add the file, and push to Github.
 
 ```bash
 git add Singularity  
@@ -73,6 +75,8 @@ git commit -a -m "Adding Singularity file."
 git push origin master  
 ```
 
-Then I would log in to Singularity Hub with my Github account and [add the repository](https://singularity-hub.org/collections/new). A collection of builds, a Container Collection, is associated with a single repository.
+Since I am in Automated Build mode(by default), the push will triger builds in Singularity Hub. 
+
+Please note that in the Automated Build mode, Singularity Hub will only consider file changes from the push after the connection being established. That is, if one Singularity file is created before the connection, it would not be considered by Singularity Hub, unless you modified it in the following push.
 
 Next, you might want to explore your [options for building](../builds) or read about [build limits](../regulatory/limits)


### PR DESCRIPTION
This PR is created in response to the Issue: #5

### Targeted issue:
The Singularity file created before **Add a new repository** is not built.

### Explanation
In Automated Build mode, only the file changes after the connection being established will be considered. So if we follow the initial instruction by creating and pushing the Singularity file and then connecting with the Singularity Hub, this file will not trigger a build.

### Modification
It is recommended to establish the connection before pushing any Singularity file.

